### PR TITLE
feat: 댓글 Entity 생성 로직

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    testCompileOnly 'org.projectlombok:lombok' // 테스트 의존성 추가
+    testAnnotationProcessor 'org.projectlombok:lombok' // 테스트 의존성 추가
+
     // database
     runtimeOnly 'com.mysql:mysql-connector-j'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/com/project/sns/domain/comment/domain/Comment.java
+++ b/src/main/java/com/project/sns/domain/comment/domain/Comment.java
@@ -1,0 +1,88 @@
+package com.project.sns.domain.comment.domain;
+
+import com.project.sns.domain.post.domain.Post;
+import com.project.sns.domain.user.domain.User;
+import com.project.sns.global.entity.BaseEntity;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "comment")
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Getter
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    @Getter
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    @Getter
+    private Post post;
+
+    @Embedded
+    private CommentContent content;
+
+    @Builder
+    private Comment(Long id, User user, Post post, CommentContent content) {
+        this.id = id;
+        this.user = user;
+        this.post = post;
+        this.content = content;
+    }
+
+    public static Comment createComment(Post post, User user, String content) {
+        return Comment.builder()
+                      .post(post)
+                      .user(user)
+                      .content(new CommentContent(content))
+                      .build();
+    }
+
+    public String getProfileImagePath() {
+        return user.getProfilePath();
+    }
+
+    public String getAuthorName() {
+        return user.getNickname();
+    }
+
+    public boolean isCommentedBy(User user) {
+        return this.user.equals(user);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Comment comment = (Comment) o;
+        return Objects.equals(id, comment.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/project/sns/domain/comment/domain/CommentContent.java
+++ b/src/main/java/com/project/sns/domain/comment/domain/CommentContent.java
@@ -1,0 +1,50 @@
+package com.project.sns.domain.comment.domain;
+
+import com.project.sns.global.exception.NotValidCommentContentException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentContent {
+
+    private static final int MAX_COMMNET_LENGTH = 200;
+
+    @Column(nullable = false, length = 200, columnDefinition = "TEXT")
+    @Getter
+    private String content;
+
+
+    public CommentContent(String content) {
+        if (isNotValidContent(content)) {
+            throw new NotValidCommentContentException("댓글 양식을 준수하지 않는 댓글입니다.");
+        }
+        this.content = content;
+    }
+
+    private boolean isNotValidContent(String content) {
+        return Objects.isNull(content) || content.isBlank()
+                || content.length() >= MAX_COMMNET_LENGTH;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CommentContent that = (CommentContent) o;
+        return Objects.equals(content, that.getContent());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(content);
+    }
+}

--- a/src/main/java/com/project/sns/domain/comment/domain/Comments.java
+++ b/src/main/java/com/project/sns/domain/comment/domain/Comments.java
@@ -1,0 +1,26 @@
+package com.project.sns.domain.comment.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+
+@Embeddable
+public class Comments {
+
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @Getter
+    private List<Comment> comments;
+
+    public Comments() {
+        this(new ArrayList<>());
+    }
+
+    public Comments(List<Comment> comments) {
+        this.comments = comments;
+    }
+
+}

--- a/src/main/java/com/project/sns/domain/user/domain/User.java
+++ b/src/main/java/com/project/sns/domain/user/domain/User.java
@@ -16,6 +16,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -69,8 +70,12 @@ public class User extends BaseEntity {
     private List<UserKeyword> userKeywords = new ArrayList<>();
 
     @Builder
-    private User(String oauthId, String nickname, String email, LocalDate birth, Gender gender,
-            String profilePath, String profileMessage) {
+    private User(Long id, String oauthId, String nickname, String email, LocalDate birth,
+            Gender gender,
+            String profilePath, String profileMessage, Boolean isDeleted,
+            LocalDateTime lastUploadDate,
+            String refreshToken, List<UserKeyword> userKeywords) {
+        this.id = id;
         this.oauthId = oauthId;
         this.nickname = nickname;
         this.email = email;
@@ -78,7 +83,12 @@ public class User extends BaseEntity {
         this.gender = gender;
         this.profilePath = profilePath;
         this.profileMessage = profileMessage;
+        this.isDeleted = isDeleted;
+        this.lastUploadDate = lastUploadDate;
+        this.refreshToken = refreshToken;
+        this.userKeywords = userKeywords;
     }
+
 
     public static User createUser(String oauthId, String nickname, String email, LocalDate birth,
             Gender gender,
@@ -104,4 +114,21 @@ public class User extends BaseEntity {
         this.isDeleted = this.isDeleted != null && this.isDeleted;
     }
 
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        User user = (User) o;
+        return Objects.equals(id, user.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
 }

--- a/src/main/java/com/project/sns/global/entity/BaseEntity.java
+++ b/src/main/java/com/project/sns/global/entity/BaseEntity.java
@@ -14,7 +14,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public abstract class BaseEntity {
 
     @CreatedDate
-    @Column(nullable = false, updatable = false)
+    @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
 }

--- a/src/main/java/com/project/sns/global/exception/NotValidCommentContentException.java
+++ b/src/main/java/com/project/sns/global/exception/NotValidCommentContentException.java
@@ -1,0 +1,8 @@
+package com.project.sns.global.exception;
+
+public class NotValidCommentContentException extends BusinessException {
+
+    public NotValidCommentContentException(String exceptionMessage) {
+        super(400, exceptionMessage);
+    }
+}

--- a/src/test/java/com/project/sns/common/MockUser.java
+++ b/src/test/java/com/project/sns/common/MockUser.java
@@ -1,0 +1,29 @@
+package com.project.sns.common;
+
+import com.project.sns.domain.user.domain.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MockUser {
+
+    private Long id;
+
+    private String nickname;
+
+    @Builder(buildMethodName = "createMockUser")
+    public MockUser(Long id, String nickname) {
+        this.id = id;
+        this.nickname = nickname;
+    }
+
+    public User build() {
+        return User.builder()
+                   .id(id)
+                   .nickname(nickname)
+                   .build();
+    }
+
+
+}

--- a/src/test/java/com/project/sns/common/UserBuilder.java
+++ b/src/test/java/com/project/sns/common/UserBuilder.java
@@ -1,0 +1,16 @@
+package com.project.sns.common;
+
+
+import com.project.sns.domain.user.domain.User;
+
+public class UserBuilder {
+
+
+    public static User createUser(Long id, String nickname) {
+        return MockUser.builder().
+                       id(id)
+                       .nickname(nickname)
+                       .createMockUser()
+                       .build();
+    }
+}

--- a/src/test/java/com/project/sns/domain/comment/domain/CommentTest.java
+++ b/src/test/java/com/project/sns/domain/comment/domain/CommentTest.java
@@ -1,0 +1,67 @@
+package com.project.sns.domain.comment.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.project.sns.common.UserBuilder;
+import com.project.sns.domain.user.domain.User;
+import com.project.sns.global.exception.NotValidCommentContentException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class CommentTest {
+
+    @DisplayName("200자 이하의 댓글을 생성할 수 있다.")
+    @Test
+    void createComment_LengthShorterThan200_Success() {
+        // given
+        String content = "댓글 내용";
+
+        // when, then
+        assertThatCode(() -> Comment.createComment(null, null, content)).doesNotThrowAnyException();
+
+    }
+
+    @DisplayName("200자가 초과되는 댓글을 생성할 수 없다")
+    @Test
+    void createComment_LengthOver200_ExceptionThrown() {
+        // given
+        String content = "댓글 내용".repeat(40);
+
+        // when, then
+        assertThatCode(() -> Comment.createComment(null, null, content)).isInstanceOf(
+                                                                                NotValidCommentContentException.class)
+                                                                        .extracting("statusCode")
+                                                                        .isEqualTo(400);
+    }
+
+    @DisplayName("댓글 내용이 null이거나 빈 문자열이면 댓글을 생성할 수 없다.")
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"", " "})
+    void createComment_ContentIsNullOrEmpty_ExceptionThrown(String content) {
+        // given
+
+        // when, then
+        assertThatCode(() -> Comment.createComment(null, null, content)).isInstanceOf(
+                                                                                NotValidCommentContentException.class)
+                                                                        .extracting("statusCode")
+                                                                        .isEqualTo(400);
+    }
+
+    @DisplayName("댓글이 해당 유저가 작성한 댓글인지 확인한다.")
+    @Test
+    void isCommentedBy_isCommentedByCurrentUser_True() {
+
+        // given
+        User currentUser = UserBuilder.createUser(1L, "닉네임");
+        Comment comment = Comment.createComment(null, currentUser, "내용");
+
+        // when, then
+        assertThat(comment.isCommentedBy(currentUser)).isTrue();
+    }
+
+}

--- a/src/test/java/com/project/sns/domain/post/application/PostCreateUseCaseTest.java
+++ b/src/test/java/com/project/sns/domain/post/application/PostCreateUseCaseTest.java
@@ -3,6 +3,7 @@ package com.project.sns.domain.post.application;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+import com.project.sns.domain.post.application.repository.ImageRepository;
 import com.project.sns.domain.post.application.repository.PostRepository;
 import com.project.sns.domain.post.domain.Image;
 import com.project.sns.domain.post.domain.Post;
@@ -30,6 +31,8 @@ public class PostCreateUseCaseTest {
 
     @Mock
     private UserRepository userRepository;
+    @Mock
+    private ImageRepository imageRepository;
     @Mock
     private ImageDomainService imageService;
     @Mock


### PR DESCRIPTION
## 개발 파트

- [ ] FE
- [X] BE
- [ ] Other

## 개발 기능 목록

- 댓글 Entity 생성
- .

### 구현 상세
- 댓글 Entity 생성 로직
  -  200자 이하의 댓글 길이 제한 구현
  - 댓글 작성자 확인 메소드 구현

### 고민한 점 & 리뷰 포인트
